### PR TITLE
Fix debug assertion failure on Visual Studio

### DIFF
--- a/libs/acc/bvh_tree.h
+++ b/libs/acc/bvh_tree.h
@@ -261,7 +261,7 @@ BVHTree<IdxType, Vec3fType>::ssplit(typename Node::ID node_id, std::vector<AABB>
     std::pair<char, IdxType> split;
     std::vector<AABB> right_aabbs(n);
     for (char d = 0; d < 3; ++d) {
-        std::sort(&indices[node.first], &indices[node.last],
+        std::sort(indices.begin() + node.first, indices.begin() + node.last,
             [&aabbs, d] (IdxType first, IdxType second) -> bool {
                 return mid(aabbs[first], d) < mid(aabbs[second], d)
                     || (mid(aabbs[first], d) == mid(aabbs[second], d)
@@ -296,7 +296,7 @@ BVHTree<IdxType, Vec3fType>::ssplit(typename Node::ID node_id, std::vector<AABB>
     char d;
     IdxType i;
     std::tie(d, i) = split;
-    std::sort(&indices[node.first], &indices[node.last],
+    std::sort(indices.begin() + node.first, indices.begin() + node.last,
         [&aabbs, d] (std::size_t first, std::size_t second) -> bool {
             return mid(aabbs[first], d) < mid(aabbs[second], d)
                 || (mid(aabbs[first], d) == mid(aabbs[second], d)


### PR DESCRIPTION
When compiling and running `texrecon` in debug mode on Visual Studio, it exits
due to a failed debug assertion. Specifically, "`vector subscript out of range`".
This is because `BVHTree::ssplit()` in `libs/acc/bvh_tree.h` passes a pointer as the
second argument to `std::sort()` which can point one element past the end of the
vector like an iterator would. Using iterators instead of pointers fixes the
failed assertion.
